### PR TITLE
Add resume page and personalize site

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -22,6 +22,7 @@ const whenExternalScripts = (items: (() => AstroIntegration) | (() => AstroInteg
   hasExternalScripts ? (Array.isArray(items) ? items.map((item) => item()) : [items()]) : [];
 
 export default defineConfig({
+  site: 'https://drod.dev',
   output: 'static',
 
   integrations: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dantech-blog",
+  "name": "dantech2000.github.io",
   "version": "1.0.0-beta.52",
   "lockfileVersion": 3,
   "requires": true,

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
-Disallow:
+Allow: /
+
+Sitemap: https://drod.dev/sitemap-index.xml

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,6 +1,6 @@
 site:
-  name: 'DanTech Blog'
-  site: 'https://dantech2000.github.io'
+  name: 'DevOps Dan'
+  site: 'https://drod.dev'
   base: '/'
   trailingSlash: false
 
@@ -9,14 +9,14 @@ site:
 # Default SEO metadata
 metadata:
   title:
-    default: 'DanTech Blog'
-    template: '%s — DanTech Blog'
-  description: 'Technology insights, tutorials, and thoughts from a developer.'
+    default: 'DevOps Dan'
+    template: '%s — DevOps Dan'
+  description: 'DevOps insights, tutorials, and thoughts from Daniel Rodriguez.'
   robots:
     index: true
     follow: true
   openGraph:
-    site_name: 'DanTech Blog'
+    site_name: 'DevOps Dan'
     images:
       - url: '~/assets/images/default.png'
         width: 1200

--- a/src/content/post/hello-world.md
+++ b/src/content/post/hello-world.md
@@ -1,8 +1,8 @@
 ---
 publishDate: 2025-07-14T00:00:00Z
 author: Daniel Rodriguez
-title: Hello World - Welcome to DanTech Blog
-excerpt: Welcome to my new blog! This is my first post where I introduce myself and share what you can expect from DanTech Blog.
+title: Hello World - Welcome to DevOps Dan
+excerpt: Welcome to my new blog! This is my first post where I introduce myself and share what you can expect from DevOps Dan.
 image: https://images.unsplash.com/photo-1517694712202-14dd9538aa97?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80
 category: Personal
 tags:
@@ -11,23 +11,23 @@ tags:
   - introduction
 ---
 
-# Hello World! 👋
+# Hello World!
 
-Welcome to DanTech Blog! I'm excited to launch this space where I'll be sharing my thoughts, experiences, and insights about technology, programming, and software development.
+Welcome to DevOps Dan! I'm excited to launch this space where I'll be sharing my thoughts, experiences, and insights about DevOps, cloud infrastructure, and site reliability engineering.
 
 ## What to Expect
 
 In this blog, you can expect to find:
 
-- **Programming Tutorials** - Step-by-step guides on various programming languages and frameworks
-- **Technology Reviews** - My thoughts on new tools, libraries, and technologies
-- **Development Tips** - Best practices, productivity tips, and lessons learned
-- **Project Showcases** - Walktroughs of interesting projects I'm working on
-- **Industry Insights** - Analysis of trends and developments in the tech world
+- **DevOps Tutorials** - Step-by-step guides on CI/CD, infrastructure as code, and automation
+- **Cloud Infrastructure** - Deep dives into AWS, Kubernetes, and cloud architecture
+- **Tool Reviews** - My thoughts on DevOps tools, platforms, and technologies
+- **Lessons Learned** - Best practices and insights from real-world production systems
+- **Project Showcases** - Walkthroughs of interesting projects I'm working on
 
 ## About Me
 
-I'm a software developer with a passion for building things and sharing knowledge. I love exploring new technologies and finding better ways to solve problems through code.
+I'm a DevOps Engineer with over 15 years of experience in the tech industry. I'm passionate about building reliable systems, automating everything, and sharing knowledge with the community.
 
 ## This Blog's Tech Stack
 
@@ -40,10 +40,10 @@ This blog is built with some fantastic modern technologies:
 
 ## What's Next?
 
-I'm planning to publish new content regularly, covering topics that I'm passionate about and hopefully providing value to fellow developers and tech enthusiasts.
+I'm planning to publish new content regularly, covering topics that I'm passionate about and hopefully providing value to fellow DevOps engineers and tech enthusiasts.
 
 Stay tuned for upcoming posts, and feel free to reach out if you have any questions or suggestions for topics you'd like me to cover!
 
 ---
 
-_This is post #1 in the DanTech Blog series. Thanks for reading!_
+_Thanks for reading!_

--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -1,0 +1,229 @@
+// Resume data - modular structure for easy updates and additions
+
+export interface PersonalInfo {
+  name: string;
+  title: string;
+  location: string;
+  email: string;
+  phone: string;
+  summary: string;
+}
+
+export interface Experience {
+  company: string;
+  title: string;
+  location: string;
+  startDate: string;
+  endDate: string;
+  responsibilities: string[];
+  icon?: string;
+}
+
+export interface Skill {
+  name: string;
+  icon?: string;
+}
+
+export interface SkillCategory {
+  category: string;
+  skills: Skill[];
+  icon?: string;
+}
+
+export interface Certification {
+  title: string;
+  issuer: string;
+  date: string;
+  icon?: string;
+}
+
+export interface Language {
+  name: string;
+  proficiency: string;
+  icon?: string;
+}
+
+// Personal Information
+export const personalInfo: PersonalInfo = {
+  name: 'Daniel Rodriguez',
+  title: 'DevOps Engineer',
+  location: 'Los Angeles, USA',
+  email: 'dantech2000@gmail.com',
+  phone: '562-419-1479',
+  summary:
+    'Skilled Site Reliability Engineer/DevOps Engineer with hands-on experience in cloud system administration, configuration management, CI/CD, and keeping software systems running smoothly. Comfortable working with a variety of platforms and always up-to-date with the latest development tools and methods. Great at handling projects solo and love being part of a team that gets things done efficiently.',
+};
+
+// Employment History
+export const experience: Experience[] = [
+  {
+    company: 'Codecademy.com',
+    title: 'DevOps Engineer',
+    location: 'New York City, NY (Remote)',
+    startDate: 'July 2024',
+    endDate: 'Present',
+    icon: 'tabler:building',
+    responsibilities: [
+      'Primarily working with AWS Services: RDS, ElastiCache, IAM, EKS',
+      'Maintain infrastructure as code (IaC) for a majority of services using Terraform',
+      'Streamlined Product and Application deployments automation and configuration management tasks',
+      'Support and maintain internal systems, monitoring availability, latency, and overall system health with DataDog',
+      'Manage services life cycle from inception through deployment, operations, and refinement',
+      'Build out automation tooling to improve the reliability of the platform, and developer productivity',
+      'Provide hands-on technical expertise during service-impacting events, participate in on-call rotation',
+      'Collaborate with other engineers on code reviews, internal infrastructure improvements, and process enhancements',
+      'Participated in migration from CircleCI to Github Actions',
+      'Managed CloudFlare infrastructure including DNS, Caching, Page Rules',
+      'Server-less Architecture using AWS Lambda and AWS Step Functions',
+    ],
+  },
+  {
+    company: 'GoDaddy.com',
+    title: 'Site Reliability Engineer',
+    location: 'Marina Del Ray, CA (Hybrid)',
+    startDate: 'November 2018',
+    endDate: 'July 2022',
+    icon: 'tabler:server',
+    responsibilities: [
+      'Primarily working with *Nix systems (primary focus on RHEL/CentOS/Debian Linux)',
+      'Streamlined Product and Application deployments automation and configuration management tasks',
+      'Support and maintain internal systems, monitoring availability, latency, and overall system health',
+      'Manage services lifecycle from inception through deployment, operations, and refinement',
+      'Create and support automation tooling to improve the reliability of the platform',
+      'Review logs of various services for troubleshooting and performance improvement',
+      'Provide hands-on technical expertise during service-impacting events',
+      'Collaborate with other engineers on code reviews, internal infrastructure improvements, and process enhancements',
+    ],
+  },
+  {
+    company: 'Media Temple',
+    title: 'Cloud Engineer',
+    location: 'Marina Del Ray, CA (Hybrid)',
+    startDate: 'November 2016',
+    endDate: 'November 2018',
+    icon: 'tabler:cloud',
+    responsibilities: [
+      'Work with customers to design cloud-based technical architectures, migration approaches, and application optimizations',
+      'Build, deploy, and maintain cloud-based infrastructures using Infrastructure As Code (IaC) with tools like AWS CloudFormation based on technical specifications',
+      'Optimize customer infrastructure for increased traffic events',
+    ],
+  },
+  {
+    company: 'Media Temple',
+    title: 'CloudTech Support',
+    location: 'Marina Del Ray, CA (Hybrid)',
+    startDate: 'November 2015',
+    endDate: 'November 2016',
+    icon: 'tabler:headset',
+    responsibilities: [
+      'Field CloudTech Support Inbound Calls, Support Requests, and Live Chats for Media Temple Services',
+      'Expedite On-Demand Services including Database Management, Apache Tuning, MySQL Optimization, Intrusion Prevention',
+      'Troubleshoot Web Server Software (Apache & NGINX)',
+      'cPanel/WHM & Plesk Troubleshooting and Administration',
+      'CentOS/RHEL Troubleshooting and Administration',
+      'Monitor site outages with Panopta and take appropriate action to resolve these outages',
+    ],
+  },
+  {
+    company: 'Western Dental & Orthodontics',
+    title: 'IT Help Desk & Operations Technician',
+    location: 'Orange, CA (On-site)',
+    startDate: 'March 2008',
+    endDate: 'March 2014',
+    icon: 'tabler:device-desktop',
+    responsibilities: [
+      'Provide technical support and assistance to over 600 onsite & 2000 remote users',
+      'Field technical issue and information request calls and emails from users',
+      'Manage Data Center server backups daily',
+      'Install/Configure new servers for Data Center',
+      'Monitor WAN Outages & Deployments',
+      'After-hours on-call response for Data Center Outages',
+      'Complete roll out of various software & hardware releases company-wide',
+    ],
+  },
+];
+
+// Skills organized by category
+export const skills: SkillCategory[] = [
+  {
+    category: 'Cloud Platforms',
+    icon: 'tabler:cloud',
+    skills: [
+      { name: 'AWS' },
+      { name: 'CloudFlare' },
+      { name: 'Google Cloud Platform' },
+    ],
+  },
+  {
+    category: 'Infrastructure as Code',
+    icon: 'tabler:code',
+    skills: [{ name: 'Terraform' }, { name: 'AWS CDK' }],
+  },
+  {
+    category: 'Configuration Management',
+    icon: 'tabler:settings',
+    skills: [{ name: 'Puppet' }, { name: 'Ansible' }],
+  },
+  {
+    category: 'CI/CD',
+    icon: 'tabler:git-merge',
+    skills: [{ name: 'Jenkins' }, { name: 'GitHub Actions' }, { name: 'CircleCI' }],
+  },
+  {
+    category: 'Containers & Orchestration',
+    icon: 'tabler:box',
+    skills: [{ name: 'Docker' }, { name: 'Kubernetes' }, { name: 'AWS EKS' }],
+  },
+  {
+    category: 'Monitoring & Observability',
+    icon: 'tabler:chart-line',
+    skills: [{ name: 'DataDog' }, { name: 'Panopta' }, { name: 'Grafana' }, { name: 'Prometheus' }],
+  },
+  {
+    category: 'Operating Systems',
+    icon: 'tabler:terminal',
+    skills: [{ name: 'Windows/Windows Server' }, { name: 'Debian Linux' }, { name: 'MacOS' }],
+  },
+  {
+    category: 'Programming & Scripting',
+    icon: 'tabler:brackets',
+    skills: [{ name: 'Python' }, { name: 'SQL' }, { name: 'Bash' }, { name: 'Golang' }],
+  },
+  {
+    category: 'Web Servers',
+    icon: 'tabler:world',
+    skills: [{ name: 'Apache' }, { name: 'NGINX' }],
+  },
+];
+
+// Certifications
+export const certifications: Certification[] = [
+  {
+    title: 'AWS Solutions Architect - Associate',
+    issuer: 'Amazon Web Services',
+    date: 'November 2018 - November 2020',
+    icon: 'tabler:certificate',
+  },
+  {
+    title: 'VMware vSphere VCP5-DCV Certification',
+    issuer: 'Coastline Community College, Cypress, CA',
+    date: 'September 2013 - September 2014',
+    icon: 'tabler:certificate',
+  },
+];
+
+// Languages
+export const languages: Language[] = [
+  {
+    name: 'English',
+    proficiency: 'Native speaker',
+    icon: 'tabler:language',
+  },
+  {
+    name: 'Spanish',
+    proficiency: 'Highly proficient',
+    icon: 'tabler:language',
+  },
+];
+
+

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -11,6 +11,10 @@ export const headerData = {
       href: getBlogPermalink(),
     },
     {
+      text: 'Resume',
+      href: getPermalink('/resume'),
+    },
+    {
       text: 'About',
       href: getPermalink('/about'),
     },

--- a/src/pages/[...blog]/[...page].astro
+++ b/src/pages/[...blog]/[...page].astro
@@ -38,7 +38,7 @@ const metadata = {
 <Layout metadata={metadata}>
   <section class="px-6 sm:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-4xl">
     <Headline
-      subtitle="A statically generated blog example with news, tutorials, resources and other interesting content related to AstroWind"
+      subtitle="Thoughts on DevOps, cloud infrastructure, automation, and lessons learned from building reliable systems."
     >
       The Blog
     </Headline>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,228 +1,210 @@
 ---
+import Content from '~/components/widgets/Content.astro';
 import Features2 from '~/components/widgets/Features2.astro';
-import Features3 from '~/components/widgets/Features3.astro';
 import Hero from '~/components/widgets/Hero.astro';
 import Stats from '~/components/widgets/Stats.astro';
-import Steps2 from '~/components/widgets/Steps2.astro';
 import Layout from '~/layouts/PageLayout.astro';
+import { Icon } from 'astro-icon/components';
+
+import { personalInfo, skills, certifications, languages } from '~/data/resume';
 
 const metadata = {
-  title: 'About us',
+  title: `About - ${personalInfo.name}`,
+  description: personalInfo.summary,
 };
+
+// Calculate years of experience (started March 2008)
+const startYear = 2008;
+const currentYear = new Date().getFullYear();
+const yearsExperience = currentYear - startYear;
+
+// Transform skills for display
+const skillItems = skills.slice(0, 6).map((category) => ({
+  title: category.category,
+  description: category.skills.map((s) => s.name).join(', '),
+  icon: category.icon || 'tabler:check',
+}));
 ---
 
 <Layout metadata={metadata}>
-  <!-- Hero Widget ******************* -->
-
-  <Hero
-    tagline="About us"
-    image={{
-      src: 'https://images.unsplash.com/photo-1559136555-9303baea8ebd?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80',
-      alt: 'Caos Image',
-    }}
-  >
+  <!-- Hero Section -->
+  <Hero>
     <Fragment slot="title">
-      Elevate your online presence with our <br />
-      <span class="text-accent dark:text-white"> Beautiful Website Templates</span>
+      Hi, I'm <span class="text-accent dark:text-white">{personalInfo.name}</span>
     </Fragment>
 
     <Fragment slot="subtitle">
-      Donec efficitur, ipsum quis congue luctus, mauris magna convallis mauris, eu auctor nisi lectus non augue. Donec
-      quis lorem non massa vulputate efficitur ac at turpis. Sed tincidunt ex a nunc convallis, et lobortis nisi tempus.
-      Suspendisse vitae nisi eget tortor luctus maximus sed non lectus.
+      <span class="font-semibold">{personalInfo.title}</span> based in {personalInfo.location}
+    </Fragment>
+
+    <Fragment slot="content">
+      <div class="flex justify-center mt-8">
+        <img
+          src="https://github.com/dantech2000.png"
+          alt={personalInfo.name}
+          class="w-48 h-48 rounded-full shadow-lg border-4 border-primary/20 dark:border-blue-200/20"
+        />
+      </div>
     </Fragment>
   </Hero>
 
-  <!-- Stats Widget ****************** -->
+  <!-- About Me Section -->
+  <Content
+    id="about"
+    columns={1}
+    items={[]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1518432031352-d6fc5c10da5a?ixlib=rb-4.0.3&auto=format&fit=crop&w=1740&q=80',
+      alt: 'Server room with blue lights',
+    }}
+  >
+    <Fragment slot="content">
+      <h2 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-4">About Me</h2>
+      <p class="text-muted mb-6">
+        {personalInfo.summary}
+      </p>
+      <p class="text-muted mb-6">
+        My journey in tech started back in 2008 when I joined Western Dental as an IT Help Desk technician. 
+        Since then, I've grown through various roles - from CloudTech Support to Cloud Engineer, 
+        Site Reliability Engineer, and now DevOps Engineer at Codecademy.
+      </p>
+      <p class="text-muted">
+        I'm passionate about automation, infrastructure as code, and building reliable systems that scale. 
+        When I'm not working on cloud infrastructure or debugging production issues, 
+        I enjoy exploring new technologies and contributing to the DevOps community.
+      </p>
+    </Fragment>
 
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </Content>
+
+  <!-- Stats Section -->
   <Stats
-    title="Statistics about us"
+    title="By the Numbers"
     stats={[
-      { title: 'Offices', amount: '4' },
-      { title: 'Employees', amount: '248' },
-      { title: 'Templates', amount: '12' },
-      { title: 'Awards', amount: '24' },
+      { title: 'Years Experience', amount: `${yearsExperience}+` },
+      { title: 'Companies', amount: '4' },
+      { title: 'Certifications', amount: `${certifications.length}` },
+      { title: 'Languages Spoken', amount: `${languages.length}` },
     ]}
   />
 
-  <!-- Features3 Widget ************** -->
-
-  <Features3
-    title="Our templates"
-    subtitle="Etiam scelerisque, enim eget vestibulum luctus, nibh mauris blandit nulla, nec vestibulum risus justo ut enim. Praesent lacinia diam et ante imperdiet euismod."
+  <!-- Core Skills Section -->
+  <Features2
+    id="skills"
+    title="Core Expertise"
+    subtitle="The technologies and practices I specialize in"
+    tagline="What I Do"
     columns={3}
-    isBeforeContent={true}
-    items={[
-      {
-        title: 'Educational',
-        description:
-          'Morbi faucibus luctus quam, sit amet aliquet felis tempor id. Cras augue massa, ornare quis dignissim a, molestie vel nulla.',
-        icon: 'tabler:template',
-      },
-      {
-        title: 'Interior Design',
-        description:
-          'Vivamus porttitor, tortor convallis aliquam pretium, turpis enim consectetur elit, vitae egestas purus erat ac nunc nulla.',
-        icon: 'tabler:template',
-      },
-      {
-        title: 'Photography',
-        description:
-          'Duis sed lectus in nisl vehicula porttitor eget quis odio. Aliquam erat volutpat. Nulla eleifend nulla id sem fermentum.',
-        icon: 'tabler:template',
-      },
-    ]}
+    items={skillItems}
   />
 
-  <!-- Features3 Widget ************** -->
-
-  <Features3
-    columns={3}
-    isAfterContent={true}
+  <!-- What I Bring Section -->
+  <Content
+    isReversed
     items={[
       {
-        title: 'E-commerce',
-        description:
-          'Rutrum non odio at vehicula. Proin ipsum justo, dignissim in vehicula sit amet, dignissim id quam. Sed ac tincidunt sapien.',
-        icon: 'tabler:template',
+        title: 'Cloud Infrastructure',
+        description: 'Deep expertise in AWS services including EKS, RDS, Lambda, and CloudFormation. Experience with multi-cloud environments and CloudFlare.',
+        icon: 'tabler:cloud',
       },
       {
-        title: 'Blog',
-        description:
-          'Nullam efficitur volutpat sem sed fringilla. Suspendisse et enim eu orci volutpat laoreet ac vitae libero.',
-        icon: 'tabler:template',
+        title: 'Automation & CI/CD',
+        description: 'Building robust deployment pipelines with GitHub Actions, Jenkins, and CircleCI. Infrastructure automation with Terraform and Ansible.',
+        icon: 'tabler:robot',
       },
       {
-        title: 'Business',
-        description:
-          'Morbi et elit finibus, facilisis justo ut, pharetra ipsum. Donec efficitur, ipsum quis congue luctus, mauris magna.',
-        icon: 'tabler:template',
-      },
-      {
-        title: 'Branding',
-        description:
-          'Suspendisse vitae nisi eget tortor luctus maximus sed non lectus. Cras malesuada pretium placerat. Nullam venenatis dolor a ante rhoncus.',
-        icon: 'tabler:template',
-      },
-      {
-        title: 'Medical',
-        description:
-          'Vestibulum malesuada lacus id nibh posuere feugiat. Nam volutpat nulla a felis ultrices, id suscipit mauris congue. In hac habitasse platea dictumst.',
-        icon: 'tabler:template',
-      },
-      {
-        title: 'Fashion Design',
-        description:
-          'Maecenas eu tellus eget est scelerisque lacinia et a diam. Aliquam velit lorem, vehicula id fermentum et, rhoncus et purus.',
-        icon: 'tabler:template',
+        title: 'Reliability & Monitoring',
+        description: 'Implementing observability solutions with DataDog, Grafana, and Prometheus. On-call experience and incident response expertise.',
+        icon: 'tabler:chart-line',
       },
     ]}
     image={{
-      src: 'https://images.unsplash.com/photo-1504384308090-c894fdcc538d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1740&q=80',
-      alt: 'Colorful Image',
+      src: 'https://images.unsplash.com/photo-1551434678-e076c223a692?ixlib=rb-4.0.3&auto=format&fit=crop&w=1740&q=80',
+      alt: 'Team collaboration',
     }}
-  />
+  >
+    <Fragment slot="content">
+      <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">What I Bring to the Table</h3>
+      <p class="text-muted mb-6">
+        With over {yearsExperience} years in the industry, I've developed a strong foundation in building 
+        and maintaining reliable infrastructure at scale.
+      </p>
+    </Fragment>
 
-  <!-- Steps2 Widget ****************** -->
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </Content>
 
-  <Steps2
-    title="Our values"
-    subtitle="Maecenas eu tellus eget est scelerisque lacinia et a diam. Aliquam velit lorem, vehicula id fermentum et, rhoncus et purus. Nulla facilisi. Vestibulum malesuada lacus."
-    items={[
-      {
-        title: 'Customer-centric approach',
-        description:
-          'Donec id nibh neque. Quisque et fermentum tortor. Fusce vitae dolor a mauris dignissim commodo. Ut eleifend luctus condimentum.',
-      },
-      {
-        title: 'Constant Improvement',
-        description:
-          'Phasellus laoreet fermentum venenatis. Vivamus dapibus pulvinar arcu eget mattis. Fusce eget mauris leo.',
-      },
-      {
-        title: 'Ethical Practices',
-        description:
-          'Vestibulum imperdiet libero et lectus molestie, et maximus augue porta. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.',
-      },
-    ]}
-  />
-
-  <!-- Steps2 Widget ****************** -->
-
-  <Steps2
-    title="Achievements"
-    subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla, sed porttitor est nibh at nulla."
-    isReversed={true}
-    callToAction={{
-      text: 'See more',
-      href: '/',
-    }}
-    items={[
-      {
-        title: 'Global reach',
-        description: 'Nam malesuada urna in enim imperdiet tincidunt. Phasellus non tincidunt nisi, at elementum mi.',
-        icon: 'tabler:globe',
-      },
-      {
-        title: 'Positive customer feedback and reviews',
-        description:
-          'Cras semper nulla leo, eget laoreet erat cursus sed. Praesent faucibus massa in purus iaculis dictum.',
-        icon: 'tabler:message-star',
-      },
-      {
-        title: 'Awards and recognition as industry experts',
-        description:
-          'Phasellus lacinia cursus velit, eu malesuada magna pretium eu. Etiam aliquet tellus purus, blandit lobortis ex rhoncus vitae.',
-        icon: 'tabler:award',
-      },
-    ]}
-  />
-
-  <!-- Features2 Widget ************** -->
-
+  <!-- Projects Section -->
   <Features2
-    title="Our locations"
-    tagline="Find us"
-    columns={4}
-    items={[
-      {
-        title: 'EE.UU',
-        description: '1234 Lorem Ipsum St, 12345, Miami',
-      },
-      {
-        title: 'Spain',
-        description: '5678 Lorem Ipsum St, 56789, Madrid',
-      },
-      {
-        title: 'Australia',
-        description: '9012 Lorem Ipsum St, 90123, Sydney',
-      },
-      {
-        title: 'Brazil',
-        description: '3456 Lorem Ipsum St, 34567, São Paulo',
-      },
-    ]}
-  />
-
-  <!-- Features2 Widget ************** -->
-
-  <Features2
-    title="Technical Support"
-    tagline="Contact us"
+    id="projects"
+    title="Projects"
+    subtitle="Open source projects and tools I maintain"
+    tagline="My Work"
     columns={2}
     items={[
       {
-        title: 'Chat with us',
-        description:
-          'Integer luctus laoreet libero, auctor varius purus rutrum sit amet. Ut nec molestie nisi, quis eleifend mi.',
-        icon: 'tabler:messages',
+        title: 'Refresh',
+        description: 'A Go-based CLI tool to manage and monitor AWS EKS clusters and nodegroups with health checks, fast list/describe operations, and smart scaling.',
+        icon: 'tabler:brand-golang',
+        callToAction: {
+          text: 'View on GitHub',
+          href: 'https://github.com/dantech2000/refresh',
+          target: '_blank',
+        },
       },
       {
-        title: 'Call us',
-        description:
-          'Mauris faucibus finibus orci, in posuere elit viverra non. In hac habitasse platea dictumst. Cras lobortis metus a hendrerit congue.',
-        icon: 'tabler:headset',
+        title: 'flake.nix',
+        description: 'Personal Nix configuration for macOS using nix-darwin and Home Manager. Provides a declarative way to manage system and user-level configurations with a modular structure.',
+        icon: 'tabler:snowflake',
+        callToAction: {
+          text: 'View on GitHub',
+          href: 'https://github.com/dantech2000/flake.nix',
+          target: '_blank',
+        },
       },
     ]}
   />
+
+  <!-- Connect Section -->
+  <div class="py-12 md:py-20">
+    <div class="max-w-3xl mx-auto text-center px-4">
+      <h2 class="text-3xl font-bold tracking-tight dark:text-white mb-4">Let's Connect</h2>
+      <p class="text-muted mb-8">
+        I'm always interested in discussing DevOps practices, cloud architecture, 
+        or new opportunities. Feel free to reach out!
+      </p>
+      <div class="flex justify-center gap-8">
+        <a
+          href="https://github.com/dantech2000"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-2 text-muted hover:text-primary dark:hover:text-blue-200 transition-colors"
+        >
+          <Icon name="tabler:brand-github" class="w-10 h-10" />
+          <span class="text-lg font-medium">GitHub</span>
+        </a>
+        <a
+          href="https://www.linkedin.com/in/dantech2000"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-2 text-muted hover:text-primary dark:hover:text-blue-200 transition-colors"
+        >
+          <Icon name="tabler:brand-linkedin" class="w-10 h-10" />
+          <span class="text-lg font-medium">LinkedIn</span>
+        </a>
+        <a
+          href={`mailto:${personalInfo.email}`}
+          class="inline-flex items-center gap-2 text-muted hover:text-primary dark:hover:text-blue-200 transition-colors"
+        >
+          <Icon name="tabler:mail" class="w-10 h-10" />
+          <span class="text-lg font-medium">Email</span>
+        </a>
+      </div>
+    </div>
+  </div>
 </Layout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -3,21 +3,25 @@ import Layout from '~/layouts/PageLayout.astro';
 import HeroText from '~/components/widgets/HeroText.astro';
 import ContactUs from '~/components/widgets/Contact.astro';
 import Features2 from '~/components/widgets/Features2.astro';
+import { Icon } from 'astro-icon/components';
+
+import { personalInfo } from '~/data/resume';
 
 const metadata = {
-  title: 'Contact',
+  title: `Contact - ${personalInfo.name}`,
+  description: `Get in touch with ${personalInfo.name}`,
 };
 ---
 
 <Layout metadata={metadata}>
   <!-- HeroText Widget ******************* -->
 
-  <HeroText tagline="Contact" title="Let's Connect!" />
+  <HeroText tagline="Contact" title="Get In Touch" subtitle="Have a question or want to work together? I'd love to hear from you." />
 
   <ContactUs
     id="form"
-    title="Drop us a message today!"
-    subtitle="For quicker answers, explore our FAQs section. You may find the solution you're looking  for right there! If not, our support team is delighted to help you."
+    title="Send me a message"
+    subtitle="Whether you have a project in mind, a question about DevOps, or just want to connect, feel free to reach out."
     inputs={[
       {
         type: 'text',
@@ -37,43 +41,60 @@ const metadata = {
       label:
         'By submitting this contact form, you acknowledge and agree to the collection of your personal information.',
     }}
-    description="Our support team typically responds within 24 business hours."
+    description="I typically respond within 24-48 hours."
   />
 
-  <!-- Features2 Widget ************** -->
-
+  <!-- Contact Info Section -->
   <Features2
-    title="We are here to help!"
+    title="Other Ways to Connect"
+    subtitle="Prefer a different method? Here are some other ways to reach me."
+    columns={3}
     items={[
       {
-        title: 'General support',
-        description: `Chat with us for inquiries related to account management, website navigation, payment issues, accessing purchased templates or general questions about the website's functionality.`,
-      },
-      {
-        title: 'Contact sales',
-        description:
-          'Chat with us for questions about purchases, customization options, licensing for commercial use, inquiries about specific template, etc.',
-      },
-      {
-        title: 'Technical support',
-        description:
-          'Chat with us when facing issues like template installation, problems editing difficulties, compatibility issues with software or download errors, or other technical challenges related to using the templates.',
-      },
-      {
-        title: 'Phone',
-        description: '+1 (234) 567-890',
-        icon: 'tabler:headset',
-      },
-      {
         title: 'Email',
-        description: 'contact@support.com',
+        description: personalInfo.email,
         icon: 'tabler:mail',
       },
       {
         title: 'Location',
-        description: '1234 Lorem Ipsum St, 12345, Miami, EEUU',
+        description: personalInfo.location,
         icon: 'tabler:map-pin',
+      },
+      {
+        title: 'Availability',
+        description: 'Open to freelance and consulting opportunities',
+        icon: 'tabler:calendar',
       },
     ]}
   />
+
+  <!-- Social Links Section -->
+  <div class="py-12 md:py-16">
+    <div class="max-w-3xl mx-auto text-center px-4">
+      <h2 class="text-2xl font-bold tracking-tight dark:text-white mb-4">Find Me Online</h2>
+      <p class="text-muted mb-8">
+        Connect with me on social platforms or check out my work.
+      </p>
+      <div class="flex justify-center gap-8">
+        <a
+          href="https://github.com/dantech2000"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-2 text-muted hover:text-primary dark:hover:text-blue-200 transition-colors"
+        >
+          <Icon name="tabler:brand-github" class="w-10 h-10" />
+          <span class="text-lg font-medium">GitHub</span>
+        </a>
+        <a
+          href="https://www.linkedin.com/in/dantech2000"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-2 text-muted hover:text-primary dark:hover:text-blue-200 transition-colors"
+        >
+          <Icon name="tabler:brand-linkedin" class="w-10 h-10" />
+          <span class="text-lg font-medium">LinkedIn</span>
+        </a>
+      </div>
+    </div>
+  </div>
 </Layout>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -1,0 +1,140 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import Hero from '~/components/widgets/Hero.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import Features2 from '~/components/widgets/Features2.astro';
+import { Icon } from 'astro-icon/components';
+
+import { personalInfo, experience, skills, certifications, languages } from '~/data/resume';
+
+const metadata = {
+  title: `Resume - ${personalInfo.name}`,
+  description: personalInfo.summary,
+};
+
+// Transform experience data for the Steps/Timeline widget
+const experienceItems = experience.map((job) => {
+  const dateRange = `${job.location} | ${job.startDate} - ${job.endDate}`;
+  const responsibilitiesList = job.responsibilities.map((r) => `<li>${r}</li>`).join('');
+  return {
+    title: `${job.title} at ${job.company}`,
+    description: `<span class="text-sm text-muted">${dateRange}</span><ul class="mt-2 list-disc list-inside text-muted">${responsibilitiesList}</ul>`,
+    icon: job.icon || 'tabler:briefcase',
+  };
+});
+
+// Transform skills data for Features2 widget - flatten categories
+const skillItems = skills.map((category) => ({
+  title: category.category,
+  description: category.skills.map((s) => s.name).join(', '),
+  icon: category.icon || 'tabler:check',
+}));
+
+// Transform certifications for Features2 widget
+const certificationItems = certifications.map((cert) => ({
+  title: cert.title,
+  description: `${cert.issuer}<br/><span class="text-sm text-muted">${cert.date}</span>`,
+  icon: cert.icon || 'tabler:certificate',
+}));
+
+// Transform languages for Features2 widget
+const languageItems = languages.map((lang) => ({
+  title: lang.name,
+  description: lang.proficiency,
+  icon: lang.icon || 'tabler:language',
+}));
+---
+
+<Layout metadata={metadata}>
+  <!-- Hero Section - Personal Info -->
+  <Hero tagline="Resume" id="resume-hero">
+    <Fragment slot="title">
+      {personalInfo.name}
+    </Fragment>
+
+    <Fragment slot="subtitle">
+      <span class="font-semibold text-primary dark:text-blue-200">{personalInfo.title}</span>
+      <br />
+      <span class="text-sm">{personalInfo.location}</span>
+    </Fragment>
+
+    <Fragment slot="content">
+      <p class="text-muted max-w-3xl mx-auto mt-6">
+        {personalInfo.summary}
+      </p>
+    </Fragment>
+  </Hero>
+
+  <!-- Social Links -->
+  <div class="relative z-10 flex justify-center gap-8 pb-6 md:pb-8 -mt-8 md:-mt-12">
+    <a
+      href="https://github.com/dantech2000"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center gap-2 text-muted hover:text-primary dark:hover:text-blue-200 transition-colors"
+    >
+      <Icon name="tabler:brand-github" class="w-10 h-10" />
+      <span class="text-lg font-medium">GitHub</span>
+    </a>
+    <a
+      href="https://www.linkedin.com/in/dantech2000"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center gap-2 text-muted hover:text-primary dark:hover:text-blue-200 transition-colors"
+    >
+      <Icon name="tabler:brand-linkedin" class="w-10 h-10" />
+      <span class="text-lg font-medium">LinkedIn</span>
+    </a>
+  </div>
+
+  <!-- Employment History - Timeline -->
+  <Steps
+    id="experience"
+    title="Employment History"
+    subtitle="A timeline of my professional experience in DevOps and Site Reliability Engineering."
+    items={experienceItems}
+    classes={{
+      container: 'max-w-4xl py-6 md:py-8 lg:py-10',
+    }}
+  />
+
+  <!-- Skills Section -->
+  <Features2
+    id="skills"
+    title="Skills & Expertise"
+    subtitle="Technical skills and tools I work with regularly."
+    tagline="Technical Skills"
+    columns={3}
+    items={skillItems}
+    classes={{
+      container: 'py-6 md:py-8 lg:py-10',
+    }}
+  />
+
+  <!-- Certifications Section -->
+  <Features2
+    id="certifications"
+    title="Certifications"
+    subtitle="Professional certifications and credentials."
+    tagline="Credentials"
+    columns={2}
+    items={certificationItems}
+    classes={{
+      container: 'py-6 md:py-8 lg:py-10',
+    }}
+  />
+
+  <!-- Languages Section -->
+  <Features2
+    id="languages"
+    title="Languages"
+    subtitle="Languages I speak and write."
+    tagline="Communication"
+    columns={2}
+    items={languageItems}
+    classes={{
+      container: 'py-6 md:py-8 lg:py-10',
+    }}
+  />
+</Layout>
+


### PR DESCRIPTION
## Summary

This PR adds a resume page and personalizes the entire site to reflect the DevOps Dan branding.

## Changes

### New Features
- **Resume Page**: New page with employment history, skills, certifications, and languages
- **Resume Data Module**: Centralized data file (`src/data/resume.ts`) for easy updates

### Site Personalization
- Renamed site from "DanTech Blog" to "DevOps Dan"
- Updated site URL to `drod.dev`
- Redesigned **About page** with personal info, GitHub projects, and social links
- Updated **Contact page** with personalized content
- Updated **Hello World** blog post to reflect DevOps focus
- Updated blog description

### SEO Improvements
- Added site URL to `astro.config.ts` for proper sitemap generation
- Added sitemap reference to `robots.txt`

### Navigation
- Added Resume link to site navigation
- Added social links (GitHub, LinkedIn) to resume, about, and contact pages